### PR TITLE
Use javascript to add controls=true, loop=true, and play the video

### DIFF
--- a/src/napari_sphinx_theme/theme/napari_sphinx_theme/layout.html
+++ b/src/napari_sphinx_theme/theme/napari_sphinx_theme/layout.html
@@ -100,6 +100,15 @@
     </div>
 
     <script src="{{ pathto('_static/scripts/napari-sphinx-theme.js', 1) }}"></script>
+    <script>
+        // Sphinx  does not let us do that on video directly in the templates, 
+        // Do it after the fact.
+        Array.from(document.getElementsByTagName('video')).forEach(e => {
+                    e.setAttribute('loop', true)
+                    e.setAttribute('controls', true)
+                    e.play()
+        })
+    </script>
 
 {%- endblock %}
 


### PR DESCRIPTION
Should take care of napari/napari#4298.
I belive a proper fix would need to ad the `loop` and `controls` flag to
docutils itself.