### PR TITLE
Fix last click on TOC

### DIFF
--- a/src/napari_sphinx_theme/assets/napari.tsx
+++ b/src/napari_sphinx_theme/assets/napari.tsx
@@ -90,8 +90,6 @@ function highlightActivePageTocItem() {
     );
     const firstHeaderInViewport = headers[firstHeaderIndex];
 
-    if (!firstHeaderInViewport) return;
-
     if (lastLinkClicked) {
       activeHeaderIndex =
         headers.findIndex(
@@ -100,6 +98,8 @@ function highlightActivePageTocItem() {
             lastLinkClicked?.getAttribute('href')?.slice(1),
         ) ?? null;
       activeHeader = headers.at(activeHeaderIndex) ?? null;
+    } else if (!firstHeaderInViewport) {
+      return;
     } else if (
       firstHeaderInViewport.getBoundingClientRect().top <
       appBarHeight + 16 + 32


### PR DESCRIPTION
Closes #79

The issue was the code was returning too early before we check for last clicked element when highlighting TOC item. Moving the early return statement fixes the issue 