### PR TITLE
Fix admonition dropdown buttons

### DIFF
--- a/src/napari_sphinx_theme/assets/components/icons/PlusIcon.tsx
+++ b/src/napari_sphinx_theme/assets/components/icons/PlusIcon.tsx
@@ -1,0 +1,22 @@
+export function PlusIcon() {
+  return (
+    <svg
+      width="15"
+      height="16"
+      viewBox="0 0 15 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M7.20703 15.0703L7.20703 0.928178"
+        stroke="black"
+        strokeWidth="2"
+      />
+      <path
+        d="M0.135963 7.99924L14.2781 7.99925"
+        stroke="black"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}

--- a/src/napari_sphinx_theme/assets/components/icons/index.ts
+++ b/src/napari_sphinx_theme/assets/components/icons/index.ts
@@ -10,6 +10,7 @@ export * from './ImageSC';
 export * from './Menu';
 export * from './NapariHub';
 export * from './NapariLogo';
+export * from './PlusIcon';
 export * from './PopupArrow';
 export * from './Search';
 export * from './Twitter';

--- a/src/napari_sphinx_theme/assets/napari.tsx
+++ b/src/napari_sphinx_theme/assets/napari.tsx
@@ -7,7 +7,7 @@ import { ReactNode } from 'react';
 import { render } from 'react-dom';
 
 import { Calendar } from '@/components/Calendar';
-import { Close, Menu, Search } from '@/components/icons';
+import { Close, Menu, PlusIcon, Search } from '@/components/icons';
 import { theme } from '@/theme';
 
 function MaterialUIProvider({ children }: { children: ReactNode }) {
@@ -518,6 +518,20 @@ function addAutoLoopAndControlsToVideos() {
   });
 }
 
+/**
+ * Fixes issue with admonition dropdowns showing empty white space when hidden:
+ * https://github.com/napari/napari-sphinx-theme/issues/99
+ */
+function renderDropdownButtonIcons() {
+  const buttons = Array.from(
+    document.querySelectorAll('.dropdown.admonition .toggle-button'),
+  );
+
+  for (const button of buttons) {
+    render(<PlusIcon />, button);
+  }
+}
+
 function main() {
   addInPageTocInteractivity();
   highlightActivePageTocItem();
@@ -529,6 +543,7 @@ function main() {
   renderAppBarMenuButton();
   addClassToCodeBlocksWithLineNumbers();
   addAutoLoopAndControlsToVideos();
+  renderDropdownButtonIcons();
   // Wrap in setTimeout so that it runs after sphinx search JS.
   setTimeout(fixSearchInput);
   setTimeout(fixSearchContainer);

--- a/src/napari_sphinx_theme/assets/scss/components/page-content.scss
+++ b/src/napari_sphinx_theme/assets/scss/components/page-content.scss
@@ -432,6 +432,33 @@ dl {
     }
   }
 
+  &.toggle-hidden {
+    height: 40px;
+  }
+
+  .toggle-button {
+    @apply tw-z-10 tw-top-0 tw-right-0;
+    @apply tw-flex tw-items-center tw-justify-center;
+
+    width: 40px;
+    height: 40px;
+    float: unset;
+
+    &::before {
+      display: none;
+    }
+
+    svg {
+      @apply tw-transition-transform;
+
+      transform: rotate(45deg);
+    }
+
+    &.toggle-button-hidden svg {
+      transform: rotate(0);
+    }
+  }
+
   &.danger {
     --color: #ff8080;
   }


### PR DESCRIPTION
Closes #99 

- Fixes the admonition dropdown issue by changing CSS height to 0 when collapsed
- Adds plus / close icon when dropdown is closed / opened