### PR TITLE
Fix encoding on source update

### DIFF
--- a/src/napari_sphinx_theme/__init__.py
+++ b/src/napari_sphinx_theme/__init__.py
@@ -520,11 +520,11 @@ def add_google_calendar_secrets(app, exception):
         'napari-sphinx-theme.js'
     )
 
-    with open(script_path, 'r') as f:
+    with open(script_path, 'r', encoding="utf8") as f:
         source = f.read()
         source = source.replace('{google_calendar_api_key}', GOOGLE_CALENDAR_API_KEY)
 
-    with open(script_path, 'w') as f:
+    with open(script_path, 'w', encoding="utf8") as f:
         f.write(source)
 
 def setup(app):


### PR DESCRIPTION
This PR fixes building napari docs on Windows by enforcing uft8 encoding when updating `napari-sphinx-theme.js` 

it fix 
```
Extension error (napari_sphinx_theme):
Handler <function add_google_calendar_secrets at 0x0000023702186940> for event 'build-finished' threw an exception (exception: 'charmap' codec can't decode byte 0x81 in position 206595: character maps to <undefined>)
make: *** [Makefile:9: docs] Error 2
``` 
first reported here: https://github.com/napari/napari/issues/4828#issuecomment-1186293786