### PR TITLE
[Maintenance] lift sphinx pin to <6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ author = "napari team"
 
 requires-python = ">=3.7"
 dependencies = [
-  "sphinx>=3.5.4,<5",
+  "sphinx>=3.5.4,<6",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "packaging"


### PR DESCRIPTION
Closes https://github.com/napari/napari-sphinx-theme/issues/121

See the discussion there, it seems fine to lift now -- we already use `sphinx_design`.
See also: https://github.com/napari/napari/pull/6239#issuecomment-1726636601