### PR TITLE
Update deploy.yml to use trusted publisher mechanism

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,9 @@ concurrency:
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:
   build-and-deploy-book:
+    permissions:
+      contents: write
+      id-token: write
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,5 +64,6 @@ jobs:
       # If tagged version: Update release on github repo
       - uses: softprops/action-gh-release@v1
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && startsWith(github.ref, 'refs/tags')
+        tag_name: ${{ env.tag }}
         with:
           generate_release_notes: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,10 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.9]
     steps:
-      - uses: actions/checkout@v2.3.3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,9 +60,6 @@ jobs:
       - name: Publish to PyPI
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
       # If tagged version: Update release on github repo
       - uses: softprops/action-gh-release@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Install Python dependencies
-          pip install --upgrade pip build .[doc]
+          pip install --upgrade pip build ".[doc]"
 
       # Build and install the theme package.
       - name: Build and install theme


### PR DESCRIPTION
Updates the deploy action to use recent versions of upstream actions, and
deploy using the PyPI Trusted Publisher mechanism.

I have already updated the package on PyPI to allow this script as a Trusted
Publisher.

## List of commits:

- Update actions versions
- .[doc] in quotes for consistency
- Remove PyPI token -- use trusted publisher instead
- Use tag-name as in napari/napari#6359
