### PR TITLE
Remove sphinx pin to rely on upstream constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ requires-python = ">=3.7"
 dependencies = [
   "pydata-sphinx-theme==0.14.4",
   "packaging",
-  "sphinx<6",
 ]
 
 license = { file = "LICENSE" }


### PR DESCRIPTION
Don't pin Sphinx directly, as we can rely on MyST and PyData Sphinx Theme to pin it if necessary.

Related to napari/docs#334