### PR TITLE
Fixes announcement banner color for dark themes

### DIFF
--- a/napari_sphinx_theme/static/css/napari-sphinx-theme.css
+++ b/napari_sphinx_theme/static/css/napari-sphinx-theme.css
@@ -49,6 +49,7 @@ html[data-theme="dark"] {
     --pst-color-text-muted: var(--napari-dark-gray);
     --pst-color-border: var(--napari-gray);
     --pst-color-target: var(--napari-gray);
+    --pst-color-secondary-bg: #e0c7ff;
 }
 
 body {


### PR DESCRIPTION
Fixes an issue mentioned on https://github.com/napari/docs/pull/332#issuecomment-1906694584

Until this is incorporated in a new napari-sphinx-theme release, a temporary fix is in https://github.com/psobolewskiPhD/napari-docs/pull/10