### PR TITLE
[Maint] Update build_napari.yml to drop doctrees

### DIFF
--- a/.github/workflows/build_napari.yml
+++ b/.github/workflows/build_napari.yml
@@ -85,12 +85,9 @@ jobs:
           # problems with screenshots (https://github.com/napari/docs/issues/285)
           linux-setup: "echo 'skip setup'"
           linux-teardown: "echo 'skip teardown'"
-    
-      - name: remove .doctrees folder (400Mb)
-        run: rm -rf napari-docs/docs/_build/.doctrees
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: napari-docs
-          path: napari-docs/docs/_build
+          path: napari-docs/docs/_build/html/


### PR DESCRIPTION
In https://github.com/napari/docs/pull/348 the build of docs was changed slightly to not put the doctrees in the html output.
In this PR I alter the workflow that builds napari docs using the theme to account for this change.
We don't need to delete the doctrees anymore, we can just upload the html folder instead.
