### PR TITLE
Fix low contrast in 'Hide search matches' box in dark mode

### DIFF
--- a/napari_sphinx_theme/static/css/napari-sphinx-theme.css
+++ b/napari_sphinx_theme/static/css/napari-sphinx-theme.css
@@ -50,6 +50,7 @@ html[data-theme="dark"] {
     --pst-color-border: var(--napari-gray);
     --pst-color-target: var(--napari-gray);
     --pst-color-secondary-bg: #e0c7ff;
+    --pst-color-primary-text: white;
 }
 
 body {


### PR DESCRIPTION
I think this will fix the issue, but the search does not work locally so I will do a mock deployment to my fork and link here when that's done.

EDIT: Looks like it works, can you check @dstansby? https://melissawm.github.io/napari.github.io/dev/developers/contributing/testing.html