### PR TITLE
Fix search colors for PST 0.16.0

### DIFF
--- a/napari_sphinx_theme/static/css/napari-sphinx-theme.css
+++ b/napari_sphinx_theme/static/css/napari-sphinx-theme.css
@@ -341,10 +341,6 @@ button.version-switcher__button {
  sidebar
 ***************************/
 
-.bd-search {
-    border: 1px solid transparent;
-}
-
 /* Remove "Section Navigation" caption */
 .bd-links__title {
     display: none;
@@ -498,6 +494,14 @@ nav.bd-links .current>a {
 search
 ***************************/
 
+.bd-search {
+    border: 1px solid transparent;
+}
+
+.bd-search:focus-within {
+    box-shadow: 0 0 0 .1875rem var(--napari-primary-blue);
+}
+
 .form-control {
     border: 1px transparent;
 }
@@ -508,7 +512,7 @@ search
     border: none;
     box-shadow: none;
     color: var(--pst-color-text-muted);
-    outline: 3px solid var(--napari-primary-blue);
+    outline: none;
 }
 
 /***************************


### PR DESCRIPTION
I just noticed the search bar colors are off with PST 0.16.0. This PR restores the correct outline color.

Before this PR:

![Captura de imagem_20241022_160058](https://github.com/user-attachments/assets/759d4dec-cca6-4615-b62f-b5fb187d8d2c)

After this PR:

![Captura de imagem_20241022_162538](https://github.com/user-attachments/assets/9f9069aa-fdc9-43c8-80ec-8732e2d83e2e)
