### PR TITLE
Use default font for headings and body text

### DIFF
--- a/napari_sphinx_theme/static/css/napari-sphinx-theme.css
+++ b/napari_sphinx_theme/static/css/napari-sphinx-theme.css
@@ -1,7 +1,6 @@
 /***************************
  napari custom colors
 ***************************/
-@import url('https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&display=swap');
 
 html {
     --napari-primary-blue: #80d1ff;
@@ -10,7 +9,7 @@ html {
     --napari-dark-gray: #686868;
     --napari-gray: #f7f7f7;
     --pst-font-family-base: var(--pst-font-family-base-system);
-    --pst-font-family-heading: "Barlow", var(--pst-font-family-base-system);
+    --pst-font-family-heading: var(--pst-font-family-base-system);
     --pst-font-family-monospace: "JetBrains Mono", var(--pst-font-family-monospace-system);
     --pst-font-size-base: 16px;
     --pst-color-headerlink: var(--napari-dark-gray);

--- a/napari_sphinx_theme/static/css/napari-sphinx-theme.css
+++ b/napari_sphinx_theme/static/css/napari-sphinx-theme.css
@@ -9,7 +9,7 @@ html {
     --napari-light-blue: #d2efff;
     --napari-dark-gray: #686868;
     --napari-gray: #f7f7f7;
-    --pst-font-family-base: "Barlow", var(--pst-font-family-base-system);
+    --pst-font-family-base: var(--pst-font-family-base-system);
     --pst-font-family-heading: "Barlow", var(--pst-font-family-base-system);
     --pst-font-family-monospace: "JetBrains Mono", var(--pst-font-family-monospace-system);
     --pst-font-size-base: 16px;
@@ -55,7 +55,6 @@ html[data-theme="dark"] {
 
 body {
     margin: 0;
-    font-family: "Barlow", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     text-align: left;
 }
 


### PR DESCRIPTION
This PR uses the default pydata sphinx theme font for body text and headings.~~and leaves barlow for heading.~~

Addresses #88. 

2025-02-27 docs workgroup meeting agreed that removing Barlow made sense. If needed, we can revisit the fonts in a future issue/PR.