### PR TITLE
Update build_napari.yml to match the changes in napari/docs

### DIFF
--- a/.github/workflows/build_napari.yml
+++ b/.github/workflows/build_napari.yml
@@ -39,15 +39,14 @@ jobs:
         with:
           python-version: "3.10"
           cache-dependency-path: |
-            napari/setup.cfg
-            docs/requirements.txt
+            napari/pyproject.toml
 
       - uses: tlambert03/setup-qt-libs@v1
 
       - name: Install napari Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install "napari/[all]"
+          python -m pip install "napari/[pyqt5, docs]"
         env:
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
 
@@ -55,12 +54,6 @@ jobs:
         run: |
           python -c 'import napari; print(napari.__version__)'
           python -c 'import napari.layers; print(napari.layers.__doc__)'
-
-      - name: Install napari-docs Dependencies
-        run: |
-          python -m pip install -qr ${{ github.workspace }}/napari-docs/requirements.txt
-        env:
-          PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
 
       # Build and install the theme package.
       - name: Build and install theme
@@ -78,8 +71,8 @@ jobs:
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
           PIP_CONSTRAINT: ${{ github.workspace }}/napari/resources/constraints/constraints_py3.10_docs.txt
         with:
-          # using html instead of docs will skip installing requirements
-          run:  make -C napari-docs html
+          # using html-noplot to skip the gallery for faster builds
+          run:  make -C napari-docs html-noplot
           # skipping setup stops the action from running the default (tiling) window manager
           # the window manager is not necessary for docs builds at this time and it was causing
           # problems with screenshots (https://github.com/napari/docs/issues/285)


### PR DESCRIPTION
This PR updates the job that builds napari docs for the latest changes, e.g. https://github.com/napari/docs/pull/591
Additionally uses `html-noplot` to skip the gallery to make the run a bit faster.