### PR TITLE
Allow calendar theme to inherit color from Google

### DIFF
--- a/napari_sphinx_theme/static/css/napari-sphinx-theme.css
+++ b/napari_sphinx_theme/static/css/napari-sphinx-theme.css
@@ -623,9 +623,6 @@ nav.page-toc {
     --fc-button-active-border-color: var(--napari-deep-blue);
     --fc-button-hover-bg-color: var(--napari-deep-blue);
     --fc-button-hover-border-color: var(--napari-deep-blue);
-    --fc-event-bg-color: var(--napari-light-blue);
-    --fc-event-border-color: var(--napari-light-blue);
-    --fc-event-text-color: var(--napari-color-text-base);
 }
 
 .fc .fc-button:focus {


### PR DESCRIPTION
Removes explicit event color in css for calendar theme. By removing this event color, FullCalendar should inherit the colors used in Google Calendar. This will more easily allow us to differentiate community meetings and other events. I believe that Google already has nice color options that still fit our theme and will look nice (if 'imperfect')

![image](https://github.com/user-attachments/assets/f83fb5ef-b12c-48f9-b265-abe4377e007c)


Inspired by a comment from Draga in a core-dev thread on Zulip:
> I think it's totally fine to have non-community-meeting events in the calendar, I'd love to see it. Would be nice to give the community meetings their own colour though, maybe? Not sure if that's possible on the website. Just wanna make sure they're easy to spot