### PR TITLE
Update Python used in deploy workflow to 3.13

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.13]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
https://github.com/napari/napari-sphinx-theme/actions/runs/17309411169/job/49140218369
Deploy is failing because it wants Python 3.9 but we require >=3.10
I figure since this is pretty isolated we can just pop in 3.13 for long term maintenance. But we can go with another version if needed instead. 
