### PR TITLE
Fix wonky navbar

### DIFF
--- a/napari_sphinx_theme/static/css/napari-sphinx-theme.css
+++ b/napari_sphinx_theme/static/css/napari-sphinx-theme.css
@@ -229,6 +229,48 @@ h1 {
     box-shadow: none;
 }
 
+/* Workaround for wonky navbar: https: //github.com/napari/napari-sphinx-theme/issues/178 */
+@media (max-width: 1110px) {
+    .bd-header .navbar-header-items {
+        display: none !important;
+    }
+    .bd-header button.primary-toggle {
+        margin-right: 1rem;
+    }
+    html .pst-navbar-icon {
+        display: flex !important;
+    }
+    .bd-sidebar-primary .sidebar-header-items {
+        display: flex !important;
+        flex-direction: column;
+    } 
+    div#pst-primary-sidebar.bd-sidebar-primary.bd-sidebar {
+        display: none !important;
+    }
+    dialog#pst-primary-sidebar-modal.bd-sidebar-primary.bd-sidebar {
+        display: flex !important;
+    }
+    .bd-sidebar-primary {
+      border: 0;
+      flex-grow: 0.75;
+      height: 100vh;
+      left: 0;
+      margin-left: -75%;
+      max-height: 100vh;
+      max-width: 350px;
+      position: fixed;
+      top: 0;
+      transition: visibility .2s ease-out,margin .2s ease-out;
+      visibility: hidden;
+      width: 75%;
+      z-index: 1055;
+    }
+    button.btn.version-switcher__button {
+      margin-bottom: unset;
+    }
+}
+/******/
+
 .navbar-brand {
     vertical-align: middle;
     font-size: 1.25rem;


### PR DESCRIPTION
Closes #178

This PR changes the navbar/left-hand drawer behavior to be triggered at slightly larger screens (1100px instead of 960px). I chose this threshold since it seems to be the point at which the navbar starts getting wonky. 

@willingc if you can try it at your tablet, that would be great!