### PR TITLE
Bump pydata-sphinx-theme to 0.18.0 and use sticky banners

### DIFF
--- a/napari_sphinx_theme/theme.conf
+++ b/napari_sphinx_theme/theme.conf
@@ -23,6 +23,7 @@ search_bar_text = search
 show_nav_level = 1
 show_prev_next = True
 show_toc_level = 1
+sticky_banners = True
 sidebar_includehidden = True
 sidebarwidth = 270
 use_edit_page_button = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [ {name = "napari team" }]
 
 requires-python = ">=3.10"
 dependencies = [
-  "pydata-sphinx-theme>=0.16.1"
+  "pydata-sphinx-theme>=0.18.0"
 ]
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -320,7 +320,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -606,7 +606,7 @@ docs = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydata-sphinx-theme", specifier = ">=0.16.1" }]
+requires-dist = [{ name = "pydata-sphinx-theme", specifier = ">=0.18.0" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -695,7 +695,7 @@ wheels = [
 
 [[package]]
 name = "pydata-sphinx-theme"
-version = "0.17.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accessible-pygments" },
@@ -709,9 +709,9 @@ dependencies = [
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/bb/4a97aaa840b26601d6d04deca1389c35025336428706a4a732051187fbd3/pydata_sphinx_theme-0.17.0.tar.gz", hash = "sha256:529c5631582cb3328cf4814fb9eb80611d1704c854406d282a75c9c86e3a1955", size = 4990605, upload-time = "2026-04-03T13:02:20.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/81/b3fdc8b74d0cfed9e623a0fef9932376800da5daa1a85d1224cac4c131a3/pydata_sphinx_theme-0.18.0.tar.gz", hash = "sha256:b4abc95ab02600872e060db07c79e056e87b7ea653ab1ffd0e0b1fa75a3003d4", size = 5004260, upload-time = "2026-05-20T08:32:28.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/b7/a2bae25aae3568fe9f17040b31f9c190b4c5d86856d8869d0a30364a2567/pydata_sphinx_theme-0.17.0-py3-none-any.whl", hash = "sha256:cec5c92f41f4a11541b6df8210c446b4aa9c3badb7fcf2db7893405b786d5c99", size = 6820685, upload-time = "2026-04-03T13:02:18.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/cd/e0eda602060f9dc99068f8e54490812d9d34ebb134043ff0ae594cf721a4/pydata_sphinx_theme-0.18.0-py3-none-any.whl", hash = "sha256:fbe5401f26642d487e3c5b6dfcbf69b3b1d579e80dcc479a429632abe0a13929", size = 6200747, upload-time = "2026-05-20T08:32:26.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This was requested in
https://github.com/pydata/pydata-sphinx-theme/issues/2328 to see the warning that the docs is for an old version while on an anchor

Trying it out locally:

<img width="1745" height="829" alt="image" src="https://github.com/user-attachments/assets/2ab02625-1d53-4a41-b4e5-76cd03b6e447" />

<img width="1748" height="833" alt="image" src="https://github.com/user-attachments/assets/4ca78c77-7efd-41ab-a5da-b0ae68a964db" />

